### PR TITLE
chore: Add JSX.Element type and no-undef off

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -46,4 +46,12 @@ module.exports = {
       },
     ],
   },
+  overrides: [
+    {
+      files: ['*.ts', '*.mts', '*.cts', '*.tsx'],
+      rules: {
+        'no-undef': 'off',
+      },
+    },
+  ],
 };

--- a/tests/utils.ts
+++ b/tests/utils.ts
@@ -1,6 +1,6 @@
 import { render } from '@testing-library/react';
 
-const customRender = (ui, options = {}) =>
+const customRender = (ui: JSX.Element, options = {}) =>
   render(ui, {
     wrapper: ({ children }) => children,
     ...options,


### PR DESCRIPTION
https://github.com/typescript-eslint/typescript-eslint/blob/main/docs/linting/TROUBLESHOOTING.md#i-get-errors-from-the-no-undef-rule-about-global-variables-not-being-defined-even-though-there-are-no-typescript-errors